### PR TITLE
Change LiDAR and Camera visualization default to ON

### DIFF
--- a/models/turtlebot3_burger/model-1_4.sdf
+++ b/models/turtlebot3_burger/model-1_4.sdf
@@ -93,7 +93,7 @@
 
       <sensor name="hls_lfcd_lds" type="ray">
         <always_on>1</always_on>
-        <visualize>0</visualize>
+        <visualize>1</visualize>
         <pose>-0.032 0 0.171 0 0 0</pose>
         <update_rate>1800</update_rate>
         <ray>

--- a/models/turtlebot3_burger/model.sdf
+++ b/models/turtlebot3_burger/model.sdf
@@ -93,7 +93,7 @@
 
       <sensor name="hls_lfcd_lds" type="ray">
         <always_on>1</always_on>
-        <visualize>0</visualize>
+        <visualize>1</visualize>
         <pose>-0.032 0 0.171 0 0 0</pose>
         <update_rate>1800</update_rate>
         <ray>

--- a/models/turtlebot3_waffle/model-1_4.sdf
+++ b/models/turtlebot3_waffle/model-1_4.sdf
@@ -113,7 +113,7 @@
 
       <sensor name="hls_lfcd_lds" type="ray">
         <always_on>1</always_on>
-        <visualize>0</visualize>
+        <visualize>1</visualize>
         <pose>-0.064 0 0.121 0 0 0</pose>
         <update_rate>1800</update_rate>
         <ray>
@@ -164,7 +164,7 @@
 
       <sensor name="intel_realsense_r200" type="camera">
         <always_on>1</always_on>
-        <visualize>0</visualize>
+        <visualize>1</visualize>
         <update_rate>30</update_rate>
         <pose>0.064 -0.047 0.107 0 0 0</pose>
         <camera>

--- a/models/turtlebot3_waffle/model.sdf
+++ b/models/turtlebot3_waffle/model.sdf
@@ -113,7 +113,7 @@
 
       <sensor name="hls_lfcd_lds" type="ray">
         <always_on>1</always_on>
-        <visualize>0</visualize>
+        <visualize>1</visualize>
         <pose>-0.064 0 0.121 0 0 0</pose>
         <update_rate>1800</update_rate>
         <ray>
@@ -164,7 +164,7 @@
 
       <sensor name="intel_realsense_r200" type="camera">
         <always_on>1</always_on>
-        <visualize>0</visualize>
+        <visualize>1</visualize>
         <update_rate>30</update_rate>
         <pose>0.064 -0.047 0.107 0 0 0</pose>
         <camera>

--- a/models/turtlebot3_waffle_pi/model-1_4.sdf
+++ b/models/turtlebot3_waffle_pi/model-1_4.sdf
@@ -113,7 +113,7 @@
 
       <sensor name="hls_lfcd_lds" type="ray">
         <always_on>1</always_on>
-        <visualize>0</visualize>
+        <visualize>1</visualize>
         <pose>-0.064 0 0.121 0 0 0</pose>
         <update_rate>1800</update_rate>
         <ray>
@@ -165,7 +165,7 @@
       <sensor name="raspberry_pi_cam" type="camera">
         <pose>0.076 0 0.094 0 0 0</pose>
         <always_on>1</always_on>
-        <visualize>0</visualize>
+        <visualize>1</visualize>
         <update_rate>30</update_rate>
         <camera>
             <horizontal_fov>1.085595</horizontal_fov>

--- a/models/turtlebot3_waffle_pi/model.sdf
+++ b/models/turtlebot3_waffle_pi/model.sdf
@@ -113,7 +113,7 @@
 
       <sensor name="hls_lfcd_lds" type="ray">
         <always_on>1</always_on>
-        <visualize>0</visualize>
+        <visualize>1</visualize>
         <pose>-0.064 0 0.121 0 0 0</pose>
         <update_rate>1800</update_rate>
         <ray>
@@ -165,7 +165,7 @@
       <sensor name="raspberry_pi_cam" type="camera">
         <pose>0.076 0 0.094 0 0 0</pose>
         <always_on>1</always_on>
-        <visualize>0</visualize>
+        <visualize>1</visualize>
         <update_rate>30</update_rate>
         <camera>
             <horizontal_fov>1.085595</horizontal_fov>


### PR DESCRIPTION
Changes to the following items in the Turtlebot3 e-manual
http://emanual.robotis.com/docs/en/platform/turtlebot3/simulation/#standalone-gazebo-plugin

The initial value is modified so that LiDAR and Camera are visualized at startup.